### PR TITLE
Fix README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This is the PyTorch implementation of [GANs N’ Roses: Stable, Controllable, Di
 >**Abstract:**<br>
 >We show how to learn a map that takes a content code, derived from a face image, and a randomly chosen style code to an anime image. We derive an adversarial loss from our simple and effective definitions of style and content. This adversarial loss guarantees the map is diverse -- a very wide range of anime can be produced from a single content code. Under plausible assumptions, the map is not just diverse, but also correctly represents the probability of an anime, conditioned on an input face. In contrast, current multimodal generation procedures cannot capture the complex styles that appear in anime.  Extensive quantitative experiments support the idea the map is correct. Extensive qualitative results show that the method can generate a much more diverse range of styles than SOTA comparisons. Finally, we show that our formalization of content and style allows us to perform video to video translation without ever training on videos.
 
-[Demo and Docker image on Replicate](https://replicate.com/vccheng2001/gans-n-roses)
-<a href="https://replicate.com/vccheng2001/gans-n-roses"><img src="https://replicate.com/vccheng2001/gans-n-roses/badge"></a>
+[Demo and Docker image on Replicate](https://replicate.com/mchong6/gans-n-roses)
+<a href="https://replicate.com/mchong6/gans-n-roses"><img src="https://replicate.com/mchong6/gans-n-roses/badge"></a>
 
 
 [Gradio Web Demo](https://gradio.app/hub/AK391/GANsNRoses)


### PR DESCRIPTION
Previous link to Replicate web demo in README.md file had a typo; fixed. And please claim the model here: https://replicate.com/mchong6/gans-n-roses to make it public! Thanks! 